### PR TITLE
Various updates to the tool

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ readEnvironmentVariables(configSchema, config);
 
 var validate = require('jsonschema').validate;
 var result = validate(config, configSchema);
+
 if (result.errors.length > 0) {
   console.log('Config file invalid', result);
   process.exit(1);

--- a/config.sample.json
+++ b/config.sample.json
@@ -9,7 +9,11 @@
     "url": "ldaps://ldap.example.com",
     "baseDN": "OU=AADDC Users,DC=example,DC=com",
     "username": "ldap@example.com",
-    "password": "mY_S3Cr3T_P455W0Rd",
-    "groupPrefix": "gitlab-"
-  }
+    "password": "mY_S3Cr3T_P455W0Rd"
+  },
+  "groupPrefix": "gitlab-",
+  "ownersGroups": "admins",
+  "ownerAccessLevel": 50,
+  "defaultAccessLevel": 30
+
 }

--- a/routes/gitlab.js
+++ b/routes/gitlab.js
@@ -3,9 +3,11 @@ var router = express.Router();
 
 /* GET users listing. */
 router.post('/webhook', function (req, res) {
-  console.log(req);
+  console.log(req.body);
   if (req.body.event_name === 'user_create') {
     gitlabLdapGroupSync.sync();
+    res.status(200).send('OK');
+  } else if(req.body.event_name) {
     res.status(200).send('OK');
   } else {
     res.status(422).send('This is not a valid gitlab system hook');


### PR DESCRIPTION
    Updating the tool with the following:
    
    * The tool will no longer download all LDAP groups, instead it only downlodas the LDAP groups corresponding to projects within the system
    * The "groupPrefix" key has been moved to the top-level of the configuration, but is now implemented.  The default "gitlab-" means that a gitlab group called "test" will have users from the LDAP group 'gitla
    * The new configuration key "owners" indicates the group name which containers users who will be given "owner" permissions.  Note that the "groupPrefix" is applied to this name.  Note that all users in this 
    * The old behaviour of gitlab-default (or ${groupPrefix}default) is used where the group does not exist (or has no entries)
    * The definition of Owner and the default access level can be defined.  These default to "50" for owner and "30" for other users (which follows the previous behaviour).
    * The gitlab hook function for user addition has been modified so that it returns 200 if invoked with what appears to be a valid request, but only triggers reprocessing if the request is a user add.
